### PR TITLE
Fix optional wait_for in async email reload

### DIFF
--- a/perplexity_async/emailnator.py
+++ b/perplexity_async/emailnator.py
@@ -88,8 +88,8 @@ class Emailnator(AsyncMixin):
             for msg in (await self.s.post('https://www.emailnator.com/message-list', json={'email': self.email})).json()['messageData']:
                 if msg['messageID'] not in self.inbox_ads and msg not in self.inbox:
                     self.new_msgs.append(msg)
-                    
-                    if wait_for(msg):
+
+                    if wait_for and wait_for(msg):
                         wait_for_found = True
             
             if (wait and not self.new_msgs) or wait_for:


### PR DESCRIPTION
## Summary
- fix handling of optional `wait_for` callback in `Emailnator.reload`

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6843427eb9ec83309401899224b2c0b2