### PR TITLE
Synchronize sync and async clients with current web protocol

### DIFF
--- a/perplexity/client.py
+++ b/perplexity/client.py
@@ -1,246 +1,204 @@
-# Importing necessary modules
-# re: Regular expressions for pattern matching
-# sys: System-specific parameters and functions
-# json: JSON parsing and serialization
-# random: Random number generation
-# mimetypes: Guessing MIME types of files
-# uuid: Generating unique identifiers
-# curl_cffi: HTTP requests and multipart form data handling
-import re
-import sys
-import json
-import random
-import mimetypes
-from uuid import uuid4
-from curl_cffi import requests, CurlMime
+"""Synchronous client for the unofficial Perplexity web protocol."""
 
-# Importing Emailnator class for email generation
+import mimetypes
+import random
+import re
+from typing import Any, Dict, Iterable, Iterator, Optional
+
+from curl_cffi import CurlMime, requests
+
+from .config import (
+    API_BASE_URL,
+    API_VERSION,
+    DEFAULT_HEADERS,
+    ENDPOINT_AUTH_SESSION,
+    ENDPOINT_AUTH_SIGNIN,
+    ENDPOINT_SSE_ASK,
+    ENDPOINT_UPLOAD_URL,
+    REQUEST_TIMEOUT,
+)
 from .emailnator import Emailnator
+from .protocol import build_search_payload, file_size, parse_sse_event, validate_search
+
 
 class Client:
-    '''
-    A client for interacting with the Perplexity AI API.
-    '''
+    """Interact with Perplexity through the user's own web session."""
 
-    def __init__(self, cookies={}):
-        # Initialize an HTTP session with default headers and optional cookies
-        self.session = requests.Session(headers={
-            'accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7',
-            'accept-language': 'en-US,en;q=0.9',
-            'cache-control': 'max-age=0',
-            'dnt': '1',
-            'priority': 'u=0, i',
-            'sec-ch-ua': '"Not;A=Brand";v="24", "Chromium";v="128"',
-            'sec-ch-ua-arch': '"x86"',
-            'sec-ch-ua-bitness': '"64"',
-            'sec-ch-ua-full-version': '"128.0.6613.120"',
-            'sec-ch-ua-full-version-list': '"Not;A=Brand";v="24.0.0.0", "Chromium";v="128.0.6613.120"',
-            'sec-ch-ua-mobile': '?0',
-            'sec-ch-ua-model': '""',
-            'sec-ch-ua-platform': '"Windows"',
-            'sec-ch-ua-platform-version': '"19.0.0"',
-            'sec-fetch-dest': 'document',
-            'sec-fetch-mode': 'navigate',
-            'sec-fetch-site': 'same-origin',
-            'sec-fetch-user': '?1',
-            'upgrade-insecure-requests': '1',
-            'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36',
-        }, cookies=cookies, impersonate='chrome')
-
-        # Flags and counters for account and query management
-        self.own = bool(cookies)  # Indicates if the client uses its own account
-        self.copilot = 0 if not cookies else float('inf')  # Remaining pro queries
-        self.file_upload = 0 if not cookies else float('inf')  # Remaining file uploads
-
-        # Regular expression for extracting sign-in links
-        self.signin_regex = re.compile(r'"(https://www\\.perplexity\\.ai/api/auth/callback/email\\?callbackUrl=.*?)"')
-
-        # Unique timestamp for session identification
-        self.timestamp = format(random.getrandbits(32), '08x')
-
-        # Initialize session by making a GET request
-        self.session.get('https://www.perplexity.ai/api/auth/session')
+    def __init__(self, cookies: Optional[dict] = None):
+        cookies = dict(cookies or {})
+        self.session = requests.Session(
+            headers=DEFAULT_HEADERS.copy(),
+            cookies=cookies,
+            impersonate="chrome",
+        )
+        self.own = bool(cookies)
+        self.copilot = float("inf") if cookies else 0
+        self.file_upload = float("inf") if cookies else 0
+        self.signin_regex = re.compile(
+            r'"(https://www\.perplexity\.ai/api/auth/callback/email\?callbackUrl=.*?)"'
+        )
+        self.timestamp = format(random.getrandbits(32), "08x")
+        self.session.get(ENDPOINT_AUTH_SESSION, timeout=REQUEST_TIMEOUT)
 
     def create_account(self, cookies):
-        '''
-        Creates a new account using Emailnator cookies.
-        '''
+        """Create an account with the existing Emailnator workflow."""
+
         while True:
             try:
-                # Initialize Emailnator client
                 emailnator_cli = Emailnator(cookies)
-
-                # Send a POST request to initiate account creation
-                resp = self.session.post('https://www.perplexity.ai/api/auth/signin/email', data={
-                    'email': emailnator_cli.email,
-                    'csrfToken': self.session.cookies.get_dict()['next-auth.csrf-token'].split('%')[0],
-                    'callbackUrl': 'https://www.perplexity.ai/',
-                    'json': 'true'
-                })
-
-                # Check if the response is successful
-                if resp.ok:
-                    # Wait for the sign-in email to arrive
-                    new_msgs = emailnator_cli.reload(wait_for=lambda x: x['subject'] == 'Sign in to Perplexity', timeout=20)
-
-                    if new_msgs:
+                response = self.session.post(
+                    ENDPOINT_AUTH_SIGNIN,
+                    data={
+                        "email": emailnator_cli.email,
+                        "csrfToken": self.session.cookies.get_dict()[
+                            "next-auth.csrf-token"
+                        ].split("%")[0],
+                        "callbackUrl": f"{API_BASE_URL}/",
+                        "json": "true",
+                    },
+                    timeout=REQUEST_TIMEOUT,
+                )
+                if response.ok:
+                    new_messages = emailnator_cli.reload(
+                        wait_for=lambda message: message["subject"] == "Sign in to Perplexity",
+                        timeout=20,
+                    )
+                    if new_messages:
                         break
                 else:
-                    print('Perplexity account creating error:', resp)
-
+                    print("Perplexity account creating error:", response)
             except Exception:
                 pass
 
-        # Extract the sign-in link from the email
-        msg = emailnator_cli.get(func=lambda x: x['subject'] == 'Sign in to Perplexity')
-        new_account_link = self.signin_regex.search(emailnator_cli.open(msg['messageID'])).group(1)
+        message = emailnator_cli.get(
+            func=lambda item: item["subject"] == "Sign in to Perplexity"
+        )
+        match = self.signin_regex.search(emailnator_cli.open(message["messageID"]))
+        if not match:
+            raise RuntimeError("Perplexity sign-in link was not found in the email")
 
-        # Complete the account creation process
-        self.session.get(new_account_link)
-
-        # Update query and file upload limits
+        self.session.get(match.group(1), timeout=REQUEST_TIMEOUT)
         self.copilot = 5
         self.file_upload = 10
-
         return True
 
-    def search(self, query, mode='auto', model=None, sources=['web'], files={}, stream=False, language='en-US', follow_up=None, incognito=False):
-        '''
-        Executes a search query on Perplexity AI.
-
-        Parameters:
-        - query: The search query string.
-        - mode: Search mode ('auto', 'pro', 'reasoning', 'deep research').
-        - model: Specific model to use for the query.
-        - sources: List of sources ('web', 'scholar', 'social').
-        - files: Dictionary of files to upload.
-        - stream: Whether to stream the response.
-        - language: Language code (ISO 639).
-        - follow_up: Information for follow-up queries.
-        - incognito: Whether to enable incognito mode.
-        '''
-        # Validate input parameters
-        assert mode in ['auto', 'pro', 'reasoning', 'deep research'], 'Invalid search mode.'
-        assert model in {
-            'auto': [None],
-            'pro': [None, 'sonar', 'gpt-4.5', 'gpt-4o', 'claude 3.7 sonnet', 'gemini 2.0 flash', 'grok-2'],
-            'reasoning': [None, 'r1', 'o3-mini', 'claude 3.7 sonnet'],
-            'deep research': [None]
-        }[mode] if self.own else True, 'Invalid model for the selected mode.'
-        assert all([source in ('web', 'scholar', 'social') for source in sources]), 'Invalid sources.'
-        assert self.copilot > 0 if mode in ['pro', 'reasoning', 'deep research'] else True, 'No remaining pro queries.'
-        assert self.file_upload - len(files) >= 0 if files else True, 'File upload limit exceeded.'
-
-        # Update query and file upload counters
-        self.copilot = self.copilot - 1 if mode in ['pro', 'reasoning', 'deep research'] else self.copilot
-        self.file_upload = self.file_upload - len(files) if files else self.file_upload
-
-        # Upload files and prepare the query payload
+    def _upload_files(self, files: Dict[str, Any]) -> list[str]:
         uploaded_files = []
-        for filename, file in files.items():
-            file_type = mimetypes.guess_type(filename)[0]
-            file_upload_info = (self.session.post(
-                'https://www.perplexity.ai/rest/uploads/create_upload_url?version=2.18&source=default',
+        for filename, data in files.items():
+            content_type = mimetypes.guess_type(filename)[0] or "application/octet-stream"
+            upload_info_response = self.session.post(
+                ENDPOINT_UPLOAD_URL,
+                params={"version": API_VERSION, "source": "default"},
                 json={
-                    'content_type': file_type,
-                    'file_size': sys.getsizeof(file),
-                    'filename': filename,
-                    'force_image': False,
-                    'source': 'default',
-                }
-            )).json()
-
-            # Upload the file to the server
-            mp = CurlMime()
-            for key, value in file_upload_info['fields'].items():
-                mp.addpart(name=key, data=value)
-            mp.addpart(name='file', content_type=file_type, filename=filename, data=file)
-
-            upload_resp = self.session.post(file_upload_info['s3_bucket_url'], multipart=mp)
-
-            if not upload_resp.ok:
-                raise Exception('File upload error', upload_resp)
-
-            # Extract the uploaded file URL
-            if 'image/upload' in file_upload_info['s3_object_url']:
-                uploaded_url = re.sub(
-                    r'/private/s--.*?--/v\\d+/user_uploads/',
-                    '/private/user_uploads/',
-                    upload_resp.json()['secure_url']
+                    "content_type": content_type,
+                    "file_size": file_size(data),
+                    "filename": filename,
+                    "force_image": False,
+                    "source": "default",
+                },
+                timeout=REQUEST_TIMEOUT,
+            )
+            if not upload_info_response.ok:
+                raise RuntimeError(
+                    f"Upload URL request failed with status {upload_info_response.status_code}"
                 )
-            else:
-                uploaded_url = file_upload_info['s3_object_url']
+            upload_info = upload_info_response.json()
 
-            uploaded_files.append(uploaded_url)
+            multipart = CurlMime()
+            for key, value in upload_info["fields"].items():
+                multipart.addpart(name=key, data=value)
+            multipart.addpart(
+                name="file",
+                content_type=content_type,
+                filename=filename,
+                data=data,
+            )
 
-        # Prepare the JSON payload for the query
-        json_data = {
-            'query_str': query,
-            'params': {
-                'attachments': uploaded_files + follow_up['attachments'] if follow_up else uploaded_files,
-                'frontend_context_uuid': str(uuid4()),
-                'frontend_uuid': str(uuid4()),
-                'is_incognito': incognito,
-                'language': language,
-                'last_backend_uuid': follow_up['backend_uuid'] if follow_up else None,
-                'mode': 'concise' if mode == 'auto' else 'copilot',
-                'model_preference': {
-                    'auto': { None: 'turbo' },
-                    'pro': {
-                        None: 'pplx_pro',
-                        'sonar': 'experimental',
-                        'gpt-4.5': 'gpt45',
-                        'gpt-4o': 'gpt4o',
-                        'claude 3.7 sonnet': 'claude2',
-                        'gemini 2.0 flash': 'gemini2flash',
-                        'grok-2': 'grok'
-                    },
-                    'reasoning': {
-                        None: 'pplx_reasoning',
-                        'r1': 'r1',
-                        'o3-mini': 'o3mini',
-                        'claude 3.7 sonnet': 'claude37sonnetthinking'
-                    },
-                    'deep research': { None: 'pplx_alpha' }
-                }[mode][model],
-                'source': 'default',
-                'sources': sources,
-                'version': '2.18'
-            }
-        }
+            upload_response = self.session.post(
+                upload_info["s3_bucket_url"],
+                multipart=multipart,
+                timeout=REQUEST_TIMEOUT,
+            )
+            if not upload_response.ok:
+                raise RuntimeError(
+                    f"File upload failed with status {upload_response.status_code}"
+                )
 
-        # Send the query request and handle the response
-        resp = self.session.post('https://www.perplexity.ai/rest/sse/perplexity_ask', json=json_data, stream=True)
-        chunks = []
+            object_url = upload_info["s3_object_url"]
+            if "image/upload" in object_url:
+                secure_url = upload_response.json()["secure_url"]
+                object_url = re.sub(
+                    r"/private/s--.*?--/v\d+/user_uploads/",
+                    "/private/user_uploads/",
+                    secure_url,
+                )
+            uploaded_files.append(object_url)
 
-        def stream_response(resp):
-            '''
-            Generator for streaming responses.
-            '''
-            for chunk in resp.iter_lines(delimiter=b'\\r\\n\\r\\n'):
-                content = chunk.decode('utf-8')
+        return uploaded_files
 
-                if content.startswith('event: message\\r\\n'):
-                    content_json = json.loads(content[len('event: message\\r\\ndata: '):])
-                    content_json['text'] = json.loads(content_json['text'])
+    @staticmethod
+    def _iter_messages(response) -> Iterator[dict]:
+        for raw_event in response.iter_lines(delimiter=b"\r\n\r\n"):
+            event_name, payload = parse_sse_event(raw_event)
+            if event_name == "end_of_stream":
+                break
+            if payload is not None:
+                yield payload
 
-                    chunks.append(content_json)
-                    yield chunks[-1]
+    def search(
+        self,
+        query: str,
+        mode: str = "auto",
+        model: Optional[str] = None,
+        sources: Optional[Iterable[str]] = None,
+        files: Optional[Dict[str, Any]] = None,
+        stream: bool = False,
+        language: str = "en-US",
+        follow_up: Optional[dict] = None,
+        incognito: bool = False,
+    ):
+        sources = list(sources or ["web"])
+        files = dict(files or {})
+        validate_search(mode, model, sources)
 
-                elif content.startswith('event: end_of_stream\\r\\n'):
-                    return
+        if mode in ("pro", "reasoning", "deep research") and self.copilot <= 0:
+            raise RuntimeError("No enhanced queries remain for this session")
+        if files and self.file_upload - len(files) < 0:
+            raise RuntimeError("File upload limit exceeded")
 
+        uploaded_files = self._upload_files(files) if files else []
+        payload = build_search_payload(
+            query,
+            mode=mode,
+            model=model,
+            sources=sources,
+            uploaded_files=uploaded_files,
+            follow_up=follow_up,
+            language=language,
+            incognito=incognito,
+        )
+
+        response = self.session.post(
+            ENDPOINT_SSE_ASK,
+            json=payload,
+            stream=True,
+            timeout=REQUEST_TIMEOUT,
+        )
+        if not response.ok:
+            raise RuntimeError(
+                f"Perplexity request failed with status {response.status_code}"
+            )
+
+        if mode in ("pro", "reasoning", "deep research"):
+            self.copilot -= 1
+        if files:
+            self.file_upload -= len(files)
+
+        messages = self._iter_messages(response)
         if stream:
-            return stream_response(resp)
+            return messages
 
-        for chunk in resp.iter_lines(delimiter=b'\\r\\n\\r\\n'):
-            content = chunk.decode('utf-8')
-
-            if content.startswith('event: message\\r\\n'):
-                content_json = json.loads(content[len('event: message\\r\\ndata: '):])
-                content_json['text'] = json.loads(content_json['text'])
-
-                chunks.append(content_json)
-
-            elif content.startswith('event: end_of_stream\\r\\n'):
-                return chunks[-1]
+        last_message = {}
+        for last_message in messages:
+            pass
+        return last_message

--- a/perplexity/config.py
+++ b/perplexity/config.py
@@ -1,17 +1,41 @@
-"""Runtime configuration for the Perplexity client and MCP bridge."""
+"""Runtime configuration shared by sync, async and MCP clients."""
 
 import os
 from pathlib import Path
 
-API_BASE_URL = "https://www.perplexity.ai"
-API_VERSION = "2.18"
+API_BASE_URL = os.environ.get("PERPLEXITY_BASE_URL", "https://www.perplexity.ai").rstrip("/")
+API_VERSION = os.environ.get("PERPLEXITY_WEB_API_VERSION", "2.18")
+REQUEST_TIMEOUT = float(os.environ.get("PERPLEXITY_REQUEST_TIMEOUT", "60"))
 
 ENDPOINT_AUTH_SESSION = f"{API_BASE_URL}/api/auth/session"
 ENDPOINT_AUTH_SIGNIN = f"{API_BASE_URL}/api/auth/signin/email"
 ENDPOINT_SSE_ASK = f"{API_BASE_URL}/rest/sse/perplexity_ask"
 ENDPOINT_UPLOAD_URL = f"{API_BASE_URL}/rest/uploads/create_upload_url"
 
-LOG_FORMAT = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+SEARCH_MODES = ("auto", "pro", "reasoning", "deep research")
+SEARCH_SOURCES = ("web", "scholar", "social")
+
+MODEL_MAPPINGS = {
+    "auto": {None: "turbo"},
+    "pro": {
+        None: "pplx_pro",
+        "sonar": "experimental",
+        "gpt-5.2": "gpt52",
+        "claude-4.5-sonnet": "claude45sonnet",
+        "grok-4.1": "grok41nonreasoning",
+    },
+    "reasoning": {
+        None: "pplx_reasoning",
+        "gpt-5.2-thinking": "gpt52_thinking",
+        "claude-4.5-sonnet-thinking": "claude45sonnetthinking",
+        "gemini-3.0-pro": "gemini30pro",
+        "kimi-k2-thinking": "kimik2thinking",
+        "grok-4.1-reasoning": "grok41reasoning",
+    },
+    "deep research": {None: "pplx_alpha"},
+}
+
+LOG_FORMAT = "% (asctime)s - %(name)s - %(levelname)s - %(message)s".replace("% ", "%")
 LOG_LEVEL = os.environ.get("PERPLEXITY_LOG_LEVEL", "INFO").upper()
 _STATE_HOME = os.environ.get("XDG_STATE_HOME") or str(Path.home() / ".local" / "state")
 LOG_FILE = os.environ.get(

--- a/perplexity/config.py
+++ b/perplexity/config.py
@@ -35,7 +35,7 @@ MODEL_MAPPINGS = {
     "deep research": {None: "pplx_alpha"},
 }
 
-LOG_FORMAT = "% (asctime)s - %(name)s - %(levelname)s - %(message)s".replace("% ", "%")
+LOG_FORMAT = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 LOG_LEVEL = os.environ.get("PERPLEXITY_LOG_LEVEL", "INFO").upper()
 _STATE_HOME = os.environ.get("XDG_STATE_HOME") or str(Path.home() / ".local" / "state")
 LOG_FILE = os.environ.get(

--- a/perplexity/protocol.py
+++ b/perplexity/protocol.py
@@ -1,0 +1,130 @@
+"""Helpers for building Perplexity web payloads and parsing SSE events."""
+
+import json
+from typing import Any, Iterable, Optional, Tuple
+from uuid import uuid4
+
+from .config import API_VERSION, MODEL_MAPPINGS, SEARCH_MODES, SEARCH_SOURCES
+
+
+class ProtocolError(ValueError):
+    """Raised when a local request does not match the supported web protocol."""
+
+
+def validate_search(mode: str, model: Optional[str], sources: Iterable[str]) -> None:
+    if mode not in SEARCH_MODES:
+        raise ProtocolError(f"Unsupported search mode: {mode}")
+    if model not in MODEL_MAPPINGS[mode]:
+        allowed = [name for name in MODEL_MAPPINGS[mode] if name is not None]
+        raise ProtocolError(f"Unsupported model for {mode}: {model}. Allowed: {allowed}")
+
+    invalid_sources = [source for source in sources if source not in SEARCH_SOURCES]
+    if invalid_sources:
+        raise ProtocolError(f"Unsupported sources: {invalid_sources}")
+
+
+def build_search_payload(
+    query: str,
+    *,
+    mode: str,
+    model: Optional[str],
+    sources: Iterable[str],
+    uploaded_files: Optional[Iterable[str]] = None,
+    follow_up: Optional[dict] = None,
+    language: str = "en-US",
+    incognito: bool = False,
+) -> dict:
+    sources = list(sources)
+    validate_search(mode, model, sources)
+    uploaded_files = list(uploaded_files or [])
+    follow_up = follow_up or {}
+
+    return {
+        "query_str": query,
+        "params": {
+            "attachments": uploaded_files + list(follow_up.get("attachments", [])),
+            "frontend_context_uuid": str(uuid4()),
+            "frontend_uuid": str(uuid4()),
+            "is_incognito": incognito,
+            "language": language,
+            "last_backend_uuid": follow_up.get("backend_uuid"),
+            "mode": "concise" if mode == "auto" else "copilot",
+            "model_preference": MODEL_MAPPINGS[mode][model],
+            "source": "default",
+            "sources": sources,
+            "version": API_VERSION,
+        },
+    }
+
+
+def parse_sse_event(raw_event: Any) -> Tuple[str, Optional[dict]]:
+    """Return ``(event_name, payload)`` for one complete SSE event block."""
+
+    if isinstance(raw_event, bytes):
+        text = raw_event.decode("utf-8", errors="replace")
+    else:
+        text = str(raw_event)
+
+    normalized = text.replace("\r\n", "\n").strip()
+    if not normalized:
+        return "empty", None
+
+    event_name = "message"
+    data_lines = []
+    for line in normalized.split("\n"):
+        if line.startswith("event:"):
+            event_name = line.split(":", 1)[1].strip()
+        elif line.startswith("data:"):
+            data_lines.append(line.split(":", 1)[1].lstrip())
+
+    if event_name == "end_of_stream":
+        return event_name, None
+    if not data_lines:
+        return event_name, None
+
+    try:
+        payload = json.loads("\n".join(data_lines))
+    except json.JSONDecodeError:
+        return "invalid", None
+
+    if not isinstance(payload, dict):
+        return event_name, {"value": payload}
+
+    nested_text = payload.get("text")
+    if isinstance(nested_text, str) and nested_text:
+        try:
+            nested_text = json.loads(nested_text)
+            payload["text"] = nested_text
+        except json.JSONDecodeError:
+            pass
+
+    if isinstance(nested_text, list):
+        for step in nested_text:
+            if not isinstance(step, dict) or step.get("step_type") != "FINAL":
+                continue
+            content = step.get("content") or {}
+            answer = content.get("answer")
+            if isinstance(answer, str):
+                try:
+                    answer = json.loads(answer)
+                except json.JSONDecodeError:
+                    answer = {"answer": answer}
+            if isinstance(answer, dict):
+                payload.setdefault("answer", answer.get("answer", ""))
+                payload.setdefault("chunks", answer.get("chunks", []))
+            break
+
+    return event_name, payload
+
+
+def file_size(file_data: Any) -> int:
+    """Return the transmitted byte size instead of Python object overhead."""
+
+    if isinstance(file_data, str):
+        return len(file_data.encode("utf-8"))
+    if isinstance(file_data, (bytes, bytearray, memoryview)):
+        return len(file_data)
+    try:
+        return len(file_data)
+    except TypeError as exc:
+        raise ProtocolError("File data must provide a byte length") from exc

--- a/perplexity_async/client.py
+++ b/perplexity_async/client.py
@@ -1,10 +1,23 @@
-import re
-import sys
-import json
-import random
+"""Asynchronous client for the unofficial Perplexity web protocol."""
+
 import mimetypes
-from uuid import uuid4
-from curl_cffi import requests, CurlMime
+import random
+import re
+from typing import Any, AsyncIterator, Dict, Iterable, Optional
+
+from curl_cffi import CurlMime, requests
+
+from perplexity.config import (
+    API_BASE_URL,
+    API_VERSION,
+    DEFAULT_HEADERS,
+    ENDPOINT_AUTH_SESSION,
+    ENDPOINT_AUTH_SIGNIN,
+    ENDPOINT_SSE_ASK,
+    ENDPOINT_UPLOAD_URL,
+    REQUEST_TIMEOUT,
+)
+from perplexity.protocol import build_search_payload, file_size, parse_sse_event, validate_search
 
 from .emailnator import Emailnator
 
@@ -13,218 +26,200 @@ class AsyncMixin:
     def __init__(self, *args, **kwargs):
         self.__storedargs = args, kwargs
         self.async_initialized = False
-        
+
     async def __ainit__(self, *args, **kwargs):
         pass
-    
+
     async def __initobj(self):
-        assert not self.async_initialized
+        if self.async_initialized:
+            raise RuntimeError("Async client has already been initialized")
         self.async_initialized = True
-        
-        # pass the parameters to __ainit__ that passed to __init__
         await self.__ainit__(*self.__storedargs[0], **self.__storedargs[1])
         return self
-    
+
     def __await__(self):
         return self.__initobj().__await__()
 
+
 class Client(AsyncMixin):
-    '''
-    A client for interacting with the Perplexity AI API.
-    '''
-    async def __ainit__(self, cookies={}):
-        self.session = requests.AsyncSession(headers={
-            'accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7',
-            'accept-language': 'en-US,en;q=0.9',
-            'cache-control': 'max-age=0',
-            'dnt': '1',
-            'priority': 'u=0, i',
-            'sec-ch-ua': '"Not;A=Brand";v="24", "Chromium";v="128"',
-            'sec-ch-ua-arch': '"x86"',
-            'sec-ch-ua-bitness': '"64"',
-            'sec-ch-ua-full-version': '"128.0.6613.120"',
-            'sec-ch-ua-full-version-list': '"Not;A=Brand";v="24.0.0.0", "Chromium";v="128.0.6613.120"',
-            'sec-ch-ua-mobile': '?0',
-            'sec-ch-ua-model': '""',
-            'sec-ch-ua-platform': '"Windows"',
-            'sec-ch-ua-platform-version': '"19.0.0"',
-            'sec-fetch-dest': 'document',
-            'sec-fetch-mode': 'navigate',
-            'sec-fetch-site': 'same-origin',
-            'sec-fetch-user': '?1',
-            'upgrade-insecure-requests': '1',
-            'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36',
-        }, cookies=cookies, impersonate='chrome')
+    """Asynchronous Perplexity client using the same protocol as the sync client."""
+
+    async def __ainit__(self, cookies: Optional[dict] = None):
+        cookies = dict(cookies or {})
+        self.session = requests.AsyncSession(
+            headers=DEFAULT_HEADERS.copy(),
+            cookies=cookies,
+            impersonate="chrome",
+        )
         self.own = bool(cookies)
-        self.copilot = 0 if not cookies else float('inf')
-        self.file_upload = 0 if not cookies else float('inf')
-        self.signin_regex = re.compile(r'"(https://www\.perplexity\.ai/api/auth/callback/email\?callbackUrl=.*?)"')
-        self.timestamp = format(random.getrandbits(32), '08x')
-        await self.session.get('https://www.perplexity.ai/api/auth/session')
-    
+        self.copilot = float("inf") if cookies else 0
+        self.file_upload = float("inf") if cookies else 0
+        self.signin_regex = re.compile(
+            r'"(https://www\.perplexity\.ai/api/auth/callback/email\?callbackUrl=.*?)"'
+        )
+        self.timestamp = format(random.getrandbits(32), "08x")
+        await self.session.get(ENDPOINT_AUTH_SESSION, timeout=REQUEST_TIMEOUT)
+
     async def create_account(self, cookies):
-        '''
-        Function to create a new account
-        '''
+        """Create an account with the existing asynchronous Emailnator workflow."""
+
         while True:
             try:
                 emailnator_cli = await Emailnator(cookies)
-                
-                resp = await self.session.post('https://www.perplexity.ai/api/auth/signin/email', data={
-                    'email': emailnator_cli.email,
-                    'csrfToken': self.session.cookies.get_dict()['next-auth.csrf-token'].split('%')[0],
-                    'callbackUrl': 'https://www.perplexity.ai/',
-                    'json': 'true'
-                })
-                
-                if resp.ok:
-                    new_msgs = await emailnator_cli.reload(wait_for=lambda x: x['subject'] == 'Sign in to Perplexity', timeout=20)
-                    
-                    if new_msgs:
+                response = await self.session.post(
+                    ENDPOINT_AUTH_SIGNIN,
+                    data={
+                        "email": emailnator_cli.email,
+                        "csrfToken": self.session.cookies.get_dict()[
+                            "next-auth.csrf-token"
+                        ].split("%")[0],
+                        "callbackUrl": f"{API_BASE_URL}/",
+                        "json": "true",
+                    },
+                    timeout=REQUEST_TIMEOUT,
+                )
+                if response.ok:
+                    new_messages = await emailnator_cli.reload(
+                        wait_for=lambda message: message["subject"] == "Sign in to Perplexity",
+                        timeout=20,
+                    )
+                    if new_messages:
                         break
                 else:
-                    print('Perplexity account creating error:', resp)
-            
+                    print("Perplexity account creating error:", response)
             except Exception:
                 pass
-        
-        msg = emailnator_cli.get(func=lambda x: x['subject'] == 'Sign in to Perplexity')
-        new_account_link = self.signin_regex.search(await emailnator_cli.open(msg['messageID'])).group(1)
-        
-        await self.session.get(new_account_link)
-        
+
+        message = emailnator_cli.get(
+            func=lambda item: item["subject"] == "Sign in to Perplexity"
+        )
+        email_content = await emailnator_cli.open(message["messageID"])
+        match = self.signin_regex.search(email_content)
+        if not match:
+            raise RuntimeError("Perplexity sign-in link was not found in the email")
+
+        await self.session.get(match.group(1), timeout=REQUEST_TIMEOUT)
         self.copilot = 5
         self.file_upload = 10
-        
         return True
-    
-    async def search(self, query, mode='auto', model=None, sources=['web'], files={}, stream=False, language='en-US', follow_up=None, incognito=False):
-        '''
-        Query function
-        '''
-        assert mode in ['auto', 'pro', 'reasoning', 'deep research'], 'Search modes -> ["auto", "pro", "reasoning", "deep research"]'
-        assert model in {
-            'auto': [None],
-            'pro': [None, 'sonar', 'gpt-4.5', 'gpt-4o', 'claude 3.7 sonnet', 'gemini 2.0 flash', 'grok-2'],
-            'reasoning': [None, 'r1', 'o3-mini', 'claude 3.7 sonnet'],
-            'deep research': [None]
-        }[mode] if self.own else True, '''Models for modes -> {
-    'auto': [None],
-    'pro': [None, 'sonar', 'gpt-4.5', 'gpt-4o', 'claude 3.7 sonnet', 'gemini 2.0 flash', 'grok-2'],
-    'reasoning': [None, 'r1', 'o3-mini', 'claude 3.7 sonnet'],
-    'deep research': [None]
-}'''
-        assert all([source in ('web', 'scholar', 'social') for source in sources]), 'Sources -> ["web", "scholar", "social"]'
-        assert self.copilot > 0 if mode in ['pro', 'reasoning', 'deep research'] else True, 'You have used all of your enhanced (pro) queries'
-        assert self.file_upload - len(files) >= 0 if files else True, f'You have tried to upload {len(files)} files but you have {self.file_upload} file upload(s) remaining.'
-        
-        self.copilot = self.copilot - 1 if mode in ['pro', 'reasoning', 'deep research'] else self.copilot
-        self.file_upload = self.file_upload - len(files) if files else self.file_upload
-        
+
+    async def _upload_files(self, files: Dict[str, Any]) -> list[str]:
         uploaded_files = []
-        
-        for filename, file in files.items():
-            file_type = mimetypes.guess_type(filename)[0]
-            file_upload_info = (await self.session.post(
-                'https://www.perplexity.ai/rest/uploads/create_upload_url?version=2.18&source=default',
+        for filename, data in files.items():
+            content_type = mimetypes.guess_type(filename)[0] or "application/octet-stream"
+            upload_info_response = await self.session.post(
+                ENDPOINT_UPLOAD_URL,
+                params={"version": API_VERSION, "source": "default"},
                 json={
-                    'content_type': file_type,
-                    'file_size': sys.getsizeof(file),
-                    'filename': filename,
-                    'force_image': False,
-                    'source': 'default',
-                }
-            )).json()
-
-            mp = CurlMime()
-            for key, value in file_upload_info['fields'].items():
-                mp.addpart(name=key, data=value)
-            mp.addpart(name='file', content_type=file_type, filename=filename, data=file)
-
-            upload_resp = await self.session.post(file_upload_info['s3_bucket_url'], multipart=mp)
-            
-            if not upload_resp.ok:
-                raise Exception('File upload error', upload_resp)
-
-            if 'image/upload' in file_upload_info['s3_object_url']:
-                uploaded_url = re.sub(
-                    r'/private/s--.*?--/v\d+/user_uploads/',
-                    '/private/user_uploads/',
-                    upload_resp.json()['secure_url']
+                    "content_type": content_type,
+                    "file_size": file_size(data),
+                    "filename": filename,
+                    "force_image": False,
+                    "source": "default",
+                },
+                timeout=REQUEST_TIMEOUT,
+            )
+            if not upload_info_response.ok:
+                raise RuntimeError(
+                    f"Upload URL request failed with status {upload_info_response.status_code}"
                 )
-            else:
-                uploaded_url = file_upload_info['s3_object_url']
+            upload_info = upload_info_response.json()
 
-            uploaded_files.append(uploaded_url)
-        
-        json_data = {
-            'query_str': query,
-            'params':
-                {
-                    'attachments': uploaded_files + follow_up['attachments'] if follow_up else uploaded_files,
-                    'frontend_context_uuid': str(uuid4()),
-                    'frontend_uuid': str(uuid4()),
-                    'is_incognito': incognito,
-                    'language': language,
-                    'last_backend_uuid': follow_up['backend_uuid'] if follow_up else None,
-                    'mode': 'concise' if mode == 'auto' else 'copilot',
-                    'model_preference': {
-                        'auto': {
-                            None: 'turbo'
-                        },
-                        'pro': {
-                            None: 'pplx_pro',
-                            'sonar': 'experimental',
-                            'gpt-4.5': 'gpt45',
-                            'gpt-4o': 'gpt4o',
-                            'claude 3.7 sonnet': 'claude2',
-                            'gemini 2.0 flash': 'gemini2flash',
-                            'grok-2': 'grok'
-                        },
-                        'reasoning': {
-                            None: 'pplx_reasoning',
-                            'r1': 'r1',
-                            'o3-mini': 'o3mini',
-                            'claude 3.7 sonnet': 'claude37sonnetthinking'
-                        },
-                        'deep research': {
-                            None: 'pplx_alpha'
-                        }
-                    }[mode][model],
-                    'source': 'default',
-                    'sources': sources,
-                    'version': '2.18'
-                }
-            }
-        
-        resp = await self.session.post('https://www.perplexity.ai/rest/sse/perplexity_ask', json=json_data, stream=True)
-        chunks = []
-        
-        async def stream_response(resp):
-            async for chunk in resp.aiter_lines(delimiter=b'\r\n\r\n'):
-                content = chunk.decode('utf-8')
-                
-                if content.startswith('event: message\r\n'):
-                    content_json = json.loads(content[len('event: message\r\ndata: '):])
-                    content_json['text'] = json.loads(content_json['text'])
-                    
-                    chunks.append(content_json)
-                    yield chunks[-1]
-                
-                elif content.startswith('event: end_of_stream\r\n'):
-                    return
-        
+            multipart = CurlMime()
+            for key, value in upload_info["fields"].items():
+                multipart.addpart(name=key, data=value)
+            multipart.addpart(
+                name="file",
+                content_type=content_type,
+                filename=filename,
+                data=data,
+            )
+
+            upload_response = await self.session.post(
+                upload_info["s3_bucket_url"],
+                multipart=multipart,
+                timeout=REQUEST_TIMEOUT,
+            )
+            if not upload_response.ok:
+                raise RuntimeError(
+                    f"File upload failed with status {upload_response.status_code}"
+                )
+
+            object_url = upload_info["s3_object_url"]
+            if "image/upload" in object_url:
+                secure_url = upload_response.json()["secure_url"]
+                object_url = re.sub(
+                    r"/private/s--.*?--/v\d+/user_uploads/",
+                    "/private/user_uploads/",
+                    secure_url,
+                )
+            uploaded_files.append(object_url)
+
+        return uploaded_files
+
+    @staticmethod
+    async def _iter_messages(response) -> AsyncIterator[dict]:
+        async for raw_event in response.aiter_lines(delimiter=b"\r\n\r\n"):
+            event_name, payload = parse_sse_event(raw_event)
+            if event_name == "end_of_stream":
+                break
+            if payload is not None:
+                yield payload
+
+    async def search(
+        self,
+        query: str,
+        mode: str = "auto",
+        model: Optional[str] = None,
+        sources: Optional[Iterable[str]] = None,
+        files: Optional[Dict[str, Any]] = None,
+        stream: bool = False,
+        language: str = "en-US",
+        follow_up: Optional[dict] = None,
+        incognito: bool = False,
+    ):
+        sources = list(sources or ["web"])
+        files = dict(files or {})
+        validate_search(mode, model, sources)
+
+        if mode in ("pro", "reasoning", "deep research") and self.copilot <= 0:
+            raise RuntimeError("No enhanced queries remain for this session")
+        if files and self.file_upload - len(files) < 0:
+            raise RuntimeError("File upload limit exceeded")
+
+        uploaded_files = await self._upload_files(files) if files else []
+        payload = build_search_payload(
+            query,
+            mode=mode,
+            model=model,
+            sources=sources,
+            uploaded_files=uploaded_files,
+            follow_up=follow_up,
+            language=language,
+            incognito=incognito,
+        )
+
+        response = await self.session.post(
+            ENDPOINT_SSE_ASK,
+            json=payload,
+            stream=True,
+            timeout=REQUEST_TIMEOUT,
+        )
+        if not response.ok:
+            raise RuntimeError(
+                f"Perplexity request failed with status {response.status_code}"
+            )
+
+        if mode in ("pro", "reasoning", "deep research"):
+            self.copilot -= 1
+        if files:
+            self.file_upload -= len(files)
+
+        messages = self._iter_messages(response)
         if stream:
-            return stream_response(resp)
-        
-        async for chunk in resp.aiter_lines(delimiter=b'\r\n\r\n'):
-            content = chunk.decode('utf-8')
-            
-            if content.startswith('event: message\r\n'):
-                content_json = json.loads(content[len('event: message\r\ndata: '):])
-                content_json['text'] = json.loads(content_json['text'])
-                
-                chunks.append(content_json)
-            
-            elif content.startswith('event: end_of_stream\r\n'):
-                return chunks[-1]
+            return messages
+
+        last_message = {}
+        async for last_message in messages:
+            pass
+        return last_message

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1,0 +1,96 @@
+import json
+
+import pytest
+
+from perplexity.protocol import (
+    ProtocolError,
+    build_search_payload,
+    file_size,
+    parse_sse_event,
+    validate_search,
+)
+
+
+def test_parse_nested_final_answer():
+    nested_answer = json.dumps({"answer": "Gotowa odpowiedź", "chunks": ["a", "b"]})
+    nested_text = json.dumps(
+        [
+            {"step_type": "SEARCH", "content": {}},
+            {"step_type": "FINAL", "content": {"answer": nested_answer}},
+        ]
+    )
+    raw = (
+        "event: message\r\n"
+        f"data: {json.dumps({'text': nested_text, 'backend_uuid': 'thread-1'})}\r\n\r\n"
+    )
+
+    event_name, payload = parse_sse_event(raw)
+
+    assert event_name == "message"
+    assert payload["answer"] == "Gotowa odpowiedź"
+    assert payload["chunks"] == ["a", "b"]
+    assert isinstance(payload["text"], list)
+
+
+def test_parse_blocks_payload_without_destroying_structure():
+    original = {
+        "blocks": [
+            {
+                "intended_usage": "ask_text",
+                "markdown_block": {"answer": "Odpowiedź blokowa"},
+            }
+        ]
+    }
+    event_name, payload = parse_sse_event(
+        f"event: message\ndata: {json.dumps(original)}\n\n"
+    )
+
+    assert event_name == "message"
+    assert payload == original
+
+
+def test_end_of_stream_event():
+    assert parse_sse_event("event: end_of_stream\ndata: {}") == (
+        "end_of_stream",
+        None,
+    )
+
+
+def test_invalid_json_is_ignored():
+    assert parse_sse_event("event: message\ndata: {broken") == ("invalid", None)
+
+
+def test_current_reasoning_model_mapping_and_follow_up():
+    payload = build_search_payload(
+        "Kontynuuj analizę",
+        mode="reasoning",
+        model="gemini-3.0-pro",
+        sources=["web", "scholar"],
+        uploaded_files=["https://files.example/a.pdf"],
+        follow_up={"backend_uuid": "thread-42", "attachments": ["old.pdf"]},
+        language="pl-PL",
+        incognito=True,
+    )
+
+    params = payload["params"]
+    assert params["model_preference"] == "gemini30pro"
+    assert params["last_backend_uuid"] == "thread-42"
+    assert params["attachments"] == ["https://files.example/a.pdf", "old.pdf"]
+    assert params["sources"] == ["web", "scholar"]
+    assert params["language"] == "pl-PL"
+    assert params["is_incognito"] is True
+
+
+def test_rejects_stale_or_unknown_model():
+    with pytest.raises(ProtocolError):
+        validate_search("pro", "gpt-4o", ["web"])
+
+
+def test_rejects_unknown_source():
+    with pytest.raises(ProtocolError):
+        validate_search("auto", None, ["private-index"])
+
+
+def test_file_size_counts_transmitted_bytes():
+    assert file_size(b"1234") == 4
+    assert file_size("ą") == 2


### PR DESCRIPTION
## Zakres

Osobna aktualizacja warstwy komunikacji z Perplexity, oparta na stabilnym `main` po scaleniu PR #10.

### Zmiany

- wspólne mapowanie aktualnych modeli dla klientów sync i async;
- jeden moduł `perplexity/protocol.py` do budowania payloadów i parsowania SSE;
- obsługa starszych odpowiedzi `text` oraz nowszych bloków odpowiedzi;
- zachowanie źródeł `web`, `scholar` i `social`, trybów auto/pro/reasoning/deep research oraz kontynuacji wątku;
- dokładny rozmiar przesyłanego pliku zamiast rozmiaru obiektu Pythona;
- poprawne typy MIME i komunikaty błędów uploadu/zapytań;
- brak mutowalnych argumentów domyślnych w publicznym API;
- identyczne zachowanie streamingu dla klienta synchronicznego i asynchronicznego;
- konfigurowalny adres bazowy, wersja protokołu i timeout.

### Generator kont

Moduły Emailnator i `create_account` pozostają dostępne. PR nie usuwa tej funkcji ani nie zastępuje jej oficjalnym API.

### Testy offline

Dodano testy kontraktowe obejmujące:

- zagnieżdżony krok `FINAL`;
- strukturę `blocks[].markdown_block`;
- koniec strumienia i uszkodzony JSON;
- aktualne mapowanie modeli reasoning;
- kontynuację rozmowy i załączniki;
- odrzucanie starych/nieznanych modeli oraz źródeł;
- faktyczny rozmiar danych uploadu.

## Walidacja

Wszystkie workflowy zakończyły się powodzeniem:

- `Python application` — kompilacja, flake8 i pytest wraz z nowymi testami protokołu;
- `MCP smoke test` — instalacja paczki i zgodność parsera MCP;
- `CI/CD Perplexity Optymalizacja` — produkcyjny build frontendu.