### PR TITLE
Handle null follow-up attachments safely

### DIFF
--- a/perplexity/protocol.py
+++ b/perplexity/protocol.py
@@ -38,11 +38,12 @@ def build_search_payload(
     validate_search(mode, model, sources)
     uploaded_files = list(uploaded_files or [])
     follow_up = follow_up or {}
+    previous_attachments = list(follow_up.get("attachments") or [])
 
     return {
         "query_str": query,
         "params": {
-            "attachments": uploaded_files + list(follow_up.get("attachments", [])),
+            "attachments": uploaded_files + previous_attachments,
             "frontend_context_uuid": str(uuid4()),
             "frontend_uuid": str(uuid4()),
             "is_incognito": incognito,

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -81,6 +81,20 @@ def test_current_reasoning_model_mapping_and_follow_up():
     assert params["is_incognito"] is True
 
 
+def test_null_follow_up_attachments_are_treated_as_empty():
+    payload = build_search_payload(
+        "Kontynuuj",
+        mode="auto",
+        model=None,
+        sources=["web"],
+        uploaded_files=["new.pdf"],
+        follow_up={"backend_uuid": "thread-43", "attachments": None},
+    )
+
+    assert payload["params"]["attachments"] == ["new.pdf"]
+    assert payload["params"]["last_backend_uuid"] == "thread-43"
+
+
 def test_rejects_stale_or_unknown_model():
     with pytest.raises(ProtocolError):
         validate_search("pro", "gpt-4o", ["web"])


### PR DESCRIPTION
## Zmiana

- traktuje `follow_up.attachments = null` jak pustą listę;
- zachowuje nowe załączniki i identyfikator kontynuowanego wątku;
- dodaje test regresyjny offline.

Minimalny hotfix po audycie PR #11.